### PR TITLE
Update jarjar-abrams to 1.14.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,5 +36,5 @@ scriptedBufferLog := false
 sbtPlugin := true
 (pluginCrossBuild / sbtVersion) := targetSbtVersion
 
-libraryDependencies += "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "1.8.2"
+libraryDependencies += "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "1.14.0"
 


### PR DESCRIPTION
My use case is that I'd like to use ShadingRules.Zap which was added in a later version of jarjar than the only currently in use in sbt-shading.

Btw, I'm seeing some stuff like

```
Expected class name: argonaut.Json
Class name: foo.shaded.argonaut.Json
Exception in thread "main" java.lang.RuntimeException: Expected class name argonaut.Json, got foo.shaded.argonaut.Json
        at scala.sys.package$.error(package.scala:27)
```

from some of the scripted tests, but they run without failure. Not sure if that's a problem or if it's to be expected.