### PR TITLE
Take the platform from the ModuleID overload in orgName

### DIFF
--- a/src/main/scala/coursier/ShadingPlugin.scala
+++ b/src/main/scala/coursier/ShadingPlugin.scala
@@ -119,11 +119,7 @@ object ShadingPlugin extends AutoPlugin with ShadingPluginCompat {
   import autoImport._
 
   private def orgName(modId: ModuleID, scalaModuleInfoOpt: Option[ScalaModuleInfo]): (String, String) = {
-    val crossVer = modId.crossVersion
-    val transformName = scalaModuleInfoOpt
-      .flatMap(scalaInfo => CrossVersion(crossVer, scalaInfo.scalaFullVersion, scalaInfo.scalaBinaryVersion))
-      .getOrElse(identity[String] _)
-    (modId.organization, transformName(modId.name))
+    (modId.organization, CrossVersion(modId, scalaModuleInfoOpt).fold(modId.name)(_(modId.name)))
   }
 
   private def onlyNamespaces(isValid: String => Boolean, jar: File, println: String => Unit): Unit = {

--- a/src/sbt-test/sbt-shading/project-matrix-shading/build.sbt
+++ b/src/sbt-test/sbt-shading/project-matrix-shading/build.sbt
@@ -1,0 +1,33 @@
+// projectMatrix rather than crossProject: on sbt 2 the platform is not part of the CrossVersion,
+// which is what made shading bundle the whole classpath on a Scala.js row.
+
+// Artifacts are named in full rather than with %%, which carries the platform on sbt 2 but not on
+// sbt 1, where %%% does instead.
+def rowSettings(suffix: String) = Seq(
+  libraryDependencies += "io.argonaut" % ("argonaut" + suffix) % "6.2.5",
+  shadedDependencies += "io.argonaut" % ("argonaut" + suffix) % "foo",
+  // shading rebuilds this row's artifact name to tell its own module from its dependencies; without
+  // the platform that name matches nothing, every module counts as shaded, and packaging asserts
+  TaskKey[Unit]("checkRow") := Def.taskDyn {
+    // on sbt 2, the platform is not part of the CrossVersion, and this fails
+    val shouldFail = sbtVersion.value.startsWith("2.") && !suffix.startsWith("_2")
+    if (shouldFail) shadedPackageBin.failure.map(_ => ()) else shadedPackageBin.map(_ => ())
+  }.value
+)
+
+lazy val root = projectMatrix
+  .in(file("."))
+  // so the rows are named root and rootJS
+  .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaABIVersion("2.12.21"))
+  .enablePlugins(ShadingPlugin)
+  .settings(
+    shadingRules += ShadingRule.moveUnder("argonaut", "foo.shaded"),
+    validNamespaces += "foo",
+    // declared so it counts as a direct dependency and is not bundled with the shaded ones
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    organization := "io.get-coursier.test",
+    name := "shading-matrix-test",
+    version := "0.1.0-SNAPSHOT"
+  )
+  .jvmPlatform(Seq("2.12.21"), rowSettings("_2.12"))
+  .jsPlatform(Seq("2.12.21"), rowSettings("_sjs1_2.12"))

--- a/src/sbt-test/sbt-shading/project-matrix-shading/project/plugins.sbt
+++ b/src/sbt-test/sbt-shading/project-matrix-shading/project/plugins.sbt
@@ -1,0 +1,26 @@
+{
+  val pluginVersion = sys.props.getOrElse(
+    "plugin.version",
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  )
+
+  addSbtPlugin("io.get-coursier" % "sbt-shading" % pluginVersion)
+}
+
+// projectMatrix is in sbt 2's core. Scala.js 1.21.0 has no sbt 2 build, and 1.22.0 is the first
+// that does, while the sbt 1 job runs on Java 8, where the other tests already pin 1.21.0.
+libraryDependencies ++= {
+  val sbtV = (pluginCrossBuild / sbtBinaryVersion).value
+  val scalaV = (update / scalaBinaryVersion).value
+  def plugin(org: String, name: String, rev: String) =
+    Defaults.sbtPluginExtra(org % name % rev, sbtV, scalaV)
+  if (sbtV.startsWith("1"))
+    Seq(
+      plugin("com.eed3si9n", "sbt-projectmatrix", "0.11.0"),
+      plugin("org.scala-js", "sbt-scalajs", "1.21.0")
+    )
+  else Seq(plugin("org.scala-js", "sbt-scalajs", "1.22.0"))
+}

--- a/src/sbt-test/sbt-shading/project-matrix-shading/src/main/scala/foo/Foo.scala
+++ b/src/sbt-test/sbt-shading/project-matrix-shading/src/main/scala/foo/Foo.scala
@@ -1,0 +1,7 @@
+package foo
+
+import argonaut._
+
+object Foo {
+  val className = classOf[Json].getName
+}

--- a/src/sbt-test/sbt-shading/project-matrix-shading/test
+++ b/src/sbt-test/sbt-shading/project-matrix-shading/test
@@ -1,0 +1,2 @@
+> root/checkRow
+> rootJS/checkRow


### PR DESCRIPTION
### Problem

`orgName` rebuilds a module's artifact name to find the project's own entry in the update report (`shadedJars`). On sbt1, `CrossVersion` contains the platform prefix but not on sbt2 (so on scala.js the name came out `foo_2.13` instead of `foo_sjs1_2.13`).

Nothing errors — the name simply matches nothing, so no dependency is recognised as direct, every module in the report then counts as shaded, and the whole classpath is bundled into the jar until `onlyNamespaces` asserts.

### Solution

Use `CrossVersion(module, scalaModuleInfo)` instead It exists on both sbt1 and sbt2, although on sbt2 it still behaves exactly the same way as what we had here (but will be fixed in the next release).
